### PR TITLE
[fix/typo-pyright]: Typo and format

### DIFF
--- a/astris/__init__.py
+++ b/astris/__init__.py
@@ -5,12 +5,12 @@ from .content import JsonCollection, JsonCollectionEntry, register_json_collecti
 __version__ = "0.1.3"
 
 __all__ = [
-	"AstrisApp",
-	"Component",
-	"Element",
-	"Text",
-	"JsonCollection",
-	"JsonCollectionEntry",
-	"register_json_collection",
-	"__version__",
+    "AstrisApp",
+    "Component",
+    "Element",
+    "Text",
+    "JsonCollection",
+    "JsonCollectionEntry",
+    "register_json_collection",
+    "__version__",
 ]

--- a/astris/bootstrap/features.py
+++ b/astris/bootstrap/features.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 from astris.lib import Div, Svg, Use, H3, P, A
 
+
 class FeatureList(Div):
-    
     def __init__(self, features: list[dict]) -> None:
         super().__init__(
             class_name="row g-4 py-5 row-cols-1 row-cols-lg-3",
@@ -16,15 +16,16 @@ class FeatureList(Div):
                         A(
                             class_name="icon-link",
                             children=["Learn More"],
-                            href=feature.get("href", "#")
+                            href=feature.get("href", "#"),
                         )
                     ],
-                ) for feature in features
-            ]
+                )
+                for feature in features
+            ],
         )
 
-class IconFeature(Div):
 
+class IconFeature(Div):
     def __init__(
         self,
         icon_class: str,
@@ -47,9 +48,9 @@ class IconFeature(Div):
                 ],
             ),
             H3(class_name="fs-2 text-body-emphasis", children=[title]),
-            P(children=[description])
+            P(children=[description]),
         ]
-        
+
         if call_to_action is not None:
             children.extend(call_to_action)
 

--- a/astris/bootstrap/heroes.py
+++ b/astris/bootstrap/heroes.py
@@ -2,10 +2,17 @@ from astris.component import Component
 
 from ..lib import Div, Img, H1, P
 
+
 class CenteredHero(Div):
     """A simple centered hero section with a title and description."""
 
-    def __init__(self, title: str, description: str, logo_img_url: str, actions: list[Component] = []):
+    def __init__(
+        self,
+        title: str,
+        description: str,
+        logo_img_url: str,
+        actions: list[Component] = [],
+    ):
         super().__init__(
             class_name="px-4 py-5 my-5 text-center",
             children=[
@@ -27,8 +34,8 @@ class CenteredHero(Div):
                         Div(
                             class_name="d-grid gap-2 d-sm-flex justify-content-sm-center mb-5",
                             children=actions,
-                        )
-                    ]
-                )
+                        ),
+                    ],
+                ),
             ],
         )

--- a/astris/content.py
+++ b/astris/content.py
@@ -80,7 +80,9 @@ def _load_collection_entries(
 
         slug = _slugify(slug_value or json_file.stem)
         if slug in seen_slugs:
-            raise ValueError(f"Duplicate slug '{slug}' in collection directory: {source_dir}")
+            raise ValueError(
+                f"Duplicate slug '{slug}' in collection directory: {source_dir}"
+            )
         seen_slugs.add(slug)
 
         route = f"{route_prefix}/{slug}"

--- a/astris/lib.py
+++ b/astris/lib.py
@@ -336,10 +336,12 @@ class Legend(Element):
 
     tag = "legend"
 
+
 class Use(Element):
     """Represents a <use> element in SVG."""
 
     tag = "use"
+
 
 class Li(Element):
     """Represents a list item."""

--- a/example.py
+++ b/example.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 # Simulate that astris is an installed package
 from astris import AstrisApp, Text, register_json_collection
-from astris.lib import A, Body, Button, Div, H2, Head, Html, P, Title
+from astris.lib import A, Body, Div, H2, Head, Html, P, Title
 
 # 1. Initialize the app
 app = AstrisApp()
@@ -44,7 +44,11 @@ def post_template(entry: dict) -> Html:
             Div(
                 class_name="mb-4",
                 children=[
-                    A(href="/posts", class_name="text-decoration-none", children=["← Back to posts"]),
+                    A(
+                        href="/posts",
+                        class_name="text-decoration-none",
+                        children=["← Back to posts"],
+                    ),
                 ],
             ),
             Div(
@@ -92,7 +96,11 @@ def home():
                             "Astris is generating static pages from JSON files and exposing a read-only dev API."
                         ]
                     ),
-                    A(href="/posts", class_name="btn btn-outline-primary", children=["Browse posts"]),
+                    A(
+                        href="/posts",
+                        class_name="btn btn-outline-primary",
+                        children=["Browse posts"],
+                    ),
                 ],
             ),
         ],

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -24,7 +24,9 @@ def _route_endpoint(app: AstrisApp, path: str) -> Callable[..., JSONResponse]:
     raise AssertionError(f"Route not found: {path}")
 
 
-def test_register_json_collection_generates_detail_routes_and_build(tmp_path: Path) -> None:
+def test_register_json_collection_generates_detail_routes_and_build(
+    tmp_path: Path,
+) -> None:
     app = AstrisApp()
     posts_dir = tmp_path / "posts"
     posts_dir.mkdir()
@@ -86,7 +88,9 @@ def test_register_json_collection_exposes_read_only_api(tmp_path: Path) -> None:
         raise AssertionError("Expected HTTPException(404) for missing collection slug")
 
 
-def test_register_json_collection_template_must_return_component(tmp_path: Path) -> None:
+def test_register_json_collection_template_must_return_component(
+    tmp_path: Path,
+) -> None:
     app = AstrisApp()
     posts_dir = tmp_path / "posts"
     posts_dir.mkdir()
@@ -102,4 +106,6 @@ def test_register_json_collection_template_must_return_component(tmp_path: Path)
     except TypeError as exc:
         assert "Component" in str(exc)
     else:
-        raise AssertionError("register_json_collection should fail for invalid template")
+        raise AssertionError(
+            "register_json_collection should fail for invalid template"
+        )


### PR DESCRIPTION
This pull request primarily focuses on code style improvements for readability and consistency across several files. The changes include formatting adjustments for function signatures, argument lists, and error messages, as well as minor cleanup of imports. No functional or behavioral changes are introduced.

Code formatting and readability improvements:

* Reformatted function signatures and argument lists in `astris/bootstrap/features.py`, `astris/bootstrap/heroes.py`, and `tests/test_content.py` to improve readability and maintain consistent code style. [[1]](diffhunk://#diff-be4c64f4d76ecb43bc728a41b66dfb956ae5257ad9d44b0ce988ec6ac3382078L5-R6) [[2]](diffhunk://#diff-be4c64f4d76ecb43bc728a41b66dfb956ae5257ad9d44b0ce988ec6ac3382078L19-R28) [[3]](diffhunk://#diff-be4c64f4d76ecb43bc728a41b66dfb956ae5257ad9d44b0ce988ec6ac3382078L50-R51) [[4]](diffhunk://#diff-6d84fa5a469fd29a8ee5551d88cde8c859b39250c2869b4c2b59f51c86518983R5-R15) [[5]](diffhunk://#diff-6d84fa5a469fd29a8ee5551d88cde8c859b39250c2869b4c2b59f51c86518983L30-R39) [[6]](diffhunk://#diff-883169411234feeb94cdff4b5399a8a84b13fd72c41e7407f7bf9909b086ebe2L27-R29) [[7]](diffhunk://#diff-883169411234feeb94cdff4b5399a8a84b13fd72c41e7407f7bf9909b086ebe2L89-R93)
* Reformatted error messages for clarity in `astris/content.py` and `tests/test_content.py`. [[1]](diffhunk://#diff-2dbb9c9bb8010bd13a749b112710418a2ea70258eda69271b6df4df6e9f18b53L83-R85) [[2]](diffhunk://#diff-883169411234feeb94cdff4b5399a8a84b13fd72c41e7407f7bf9909b086ebe2L105-R111)

Minor cleanup:

* Removed unused `Button` import in `example.py` for cleaner code.
* Reformatted argument lists for `A` components in `example.py` to improve readability. [[1]](diffhunk://#diff-6a6e57c6fff6087e2cac547e260c49d313fd40975812f8f9b936c5df06233b15L47-R51) [[2]](diffhunk://#diff-6a6e57c6fff6087e2cac547e260c49d313fd40975812f8f9b936c5df06233b15L95-R103)
* Added spacing between class definitions in `astris/lib.py` for consistency.